### PR TITLE
Fix for RpmPackage

### DIFF
--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -135,17 +135,6 @@ class OpenBSDPackage(Package):
 
 class RpmPackage(Package):
 
-    def _get_package_info(self, header):
-        # Name        : bash
-        # Version     : 4.2.46
-        # Release     : 0.g9b0f0e9
-        # ...
-        out = self.check_output("rpm -qi %s", self.name)
-        for line in out.splitlines():
-            if line.startswith(header):
-                return line.split(":", 1)[1].strip()
-        raise RuntimeError("Cannot parse output '%s'" % (out,))
-
     @property
     def is_installed(self):
         return self.run_test("rpm -q %s", self.name).rc == 0
@@ -158,9 +147,4 @@ class RpmPackage(Package):
     @property
     def release(self):
         return self.check_output('rpm -q --queryformat="%%{RELEASE}" %s',
-                                 self.name)
-
-    @property
-    def releaseversion(self):
-        return self.check_output('rpm -q --queryformat="%%{EVR}" %s',
                                  self.name)

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -152,12 +152,15 @@ class RpmPackage(Package):
 
     @property
     def version(self):
-        return self.check_output('rpm -q --queryformat="%%{VERSION}" %s',self.name)
+        return self.check_output('rpm -q --queryformat="%%{VERSION}" %s',
+                                 self.name)
 
     @property
     def release(self):
-        return self.check_output('rpm -q --queryformat="%%{RELEASE}" %s',self.name)
+        return self.check_output('rpm -q --queryformat="%%{RELEASE}" %s',
+                                 self.name)
 
     @property
     def releaseversion(self):
-        return self.check_output('rpm -q --queryformat="%%{EVR}" %s',self.name)
+        return self.check_output('rpm -q --queryformat="%%{EVR}" %s',
+                                 self.name)

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -152,8 +152,12 @@ class RpmPackage(Package):
 
     @property
     def version(self):
-        return self._get_package_info("Version")
+        return self.check_output('rpm -q --queryformat="%%{VERSION}" %s',self.name)
 
     @property
     def release(self):
-        return self._get_package_info("Release")
+        return self.check_output('rpm -q --queryformat="%%{RELEASE}" %s',self.name)
+
+    @property
+    def releaseversion(self):
+        return self.check_output('rpm -q --queryformat="%%{EVR}" %s',self.name)


### PR DESCRIPTION
parsing rpm -qi was inefficient and ineffective. 

rpm -qi and line.split(":", 1)[1].strip()  were giving

```
>>> Package('acl').version
2.2.49                            Vendor: Red Hat, Inc.
```

While technically this starts with the same characters as the version, it has a bunch more we don't want to see and that have no business in the version string.

 rpm -q --queryformat gives direct output of the values we want.

Package('acl').version == '2.2.49'

This test now works:
```
def test_package_acl(Package):
    acl = Package("acl")
    assert acl.is_installed
    assert acl.version == '2.2.49'
    assert acl.release == '6.el6'

```